### PR TITLE
Remove hard coded location for opencv library

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(cv_bridge)
 
-SET(OpenCV_DIR "~/software/opencv/build")
+#SET(OpenCV_DIR "~/software/opencv/build")
+# set this using the catkin_make -D flag as: -DOpenCV_DIR=~/software/opencv/build
 
 find_package(catkin REQUIRED COMPONENTS rosconsole sensor_msgs)
 

--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(image_geometry)
 
-SET(OpenCV_DIR "~/software/opencv/build")
+#SET(OpenCV_DIR "~/software/opencv/build")
+# set this using the catkin_make -D flag as: -DOpenCV_DIR=~/software/opencv/build
 
 find_package(catkin REQUIRED sensor_msgs)
 find_package(OpenCV REQUIRED)


### PR DESCRIPTION
Pushyami, the hard-coded values cause issues when trying to install using scripts.  It would be good to remove from the repo.